### PR TITLE
Geolocation Fix and Weather Request Improvement

### DIFF
--- a/src/Shows/Shows.js
+++ b/src/Shows/Shows.js
@@ -93,7 +93,8 @@ const Shows = ({ setStartMarkerPos, setEndMarkerPos, setLatitude, setLongitude, 
             }, function (error) {
                 if (error.code === error.PERMISSION_DENIED) {
                     const latitude = 53.789402;
-                    const longitude = ;
+                    const longitude = -1.533356;
+                    setMapInformation({lat: latitude, lng: longitude, selectedIndex: selectedIndex});
                 }
             });
         } else {

--- a/src/Shows/Shows.js
+++ b/src/Shows/Shows.js
@@ -90,6 +90,11 @@ const Shows = ({ setStartMarkerPos, setEndMarkerPos, setLatitude, setLongitude, 
                 const latitude = position.coords.latitude;
                 const longitude = position.coords.longitude;
                 setMapInformation({lat: latitude, lng: longitude, selectedIndex: selectedIndex});
+            }, function (error) {
+                if (error.code === error.PERMISSION_DENIED) {
+                    const latitude = 53.789402;
+                    const longitude = ;
+                }
             });
         } else {
             console.log('Geolocation not enabled, cannot provide accurate starting position');

--- a/src/Weather/Weather.js
+++ b/src/Weather/Weather.js
@@ -10,8 +10,7 @@ const Weather = ({latitude, longitude, startName, destinationName}) => {
     const [dailyWeather, setDailyWeather] = useState([]);
     const [weatherSymbolURL, setWeatherSymbolURL] = useState("https://openweathermap.org/img/wn/02d@2x.png");
     const [expanded, setExpanded] = useState(false);
-
-    const storedWeatherSymbols = {};
+    const [storedWeatherSymbols, setStoredWeatherSymbols] = useState({});
 
     const DAYS_OF_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THU', "FRI", "SAT"];
 
@@ -74,7 +73,9 @@ const Weather = ({latitude, longitude, startName, destinationName}) => {
                 let data = parsedData;
                 data['symbolUrl'] = response.data;
                 if(!storedWeatherSymbols.hasOwnProperty(currentWeather.description)) {
-                    storedWeatherSymbols[currentWeather.description] = response.data;
+                    let tempSymbols = storedWeatherSymbols;
+                    tempSymbols[currentWeather.description] = response.data;
+                    setStoredWeatherSymbols(tempSymbols);
                 }
                 setCurrentWeather(data);
             }).catch(error => {
@@ -94,7 +95,9 @@ const Weather = ({latitude, longitude, startName, destinationName}) => {
                         }
                     }).then(response => {
                         item['symbolUrl'] = response.data;
-                        storedWeatherSymbols[item.description] = response.data;
+                        let tempSymbols = storedWeatherSymbols;
+                        tempSymbols[item.description] = response.data;
+                        setStoredWeatherSymbols(tempSymbols);
                     }).catch(error => {
                         console.log('Could not fetch weather symbols for hourly weather');
                     })


### PR DESCRIPTION
Fixed issue with show selection not working due to geolocation not being enabled (now defaults to leeds dock as the starting point) and made so that the weather component correctly stores the weather symbols that have previously been fetched so that they do not have to be re-requested.